### PR TITLE
bugfix: the priority of the concat operator should be higher than the union

### DIFF
--- a/__tests__/parser.test.js
+++ b/__tests__/parser.test.js
@@ -15,7 +15,7 @@ describe('insertExplicitConcatSymbol tests', () => {
     test('call with "a|b" should return "a|b"', () => {
         expect(insertExplicitConcatOperator('a|b')).toEqual('a|b');
     });
-    
+
     test('call with "ab" should return "a.b"', () => {
         expect(insertExplicitConcatOperator('ab')).toEqual('a.b');
     });
@@ -66,10 +66,14 @@ describe('toPostfix tests', () => {
         expect(toPostfix('a*.b')).toEqual('a*b.');
     });
 
+    test('call with "a.b|c.d" should return "ab.cd.|"', () => {
+        expect(toPostfix('a.b|c.d')).toEqual('ab.cd.|');
+    });
+
     test('call with "a|b*" should return "ab*|"', () => {
         expect(toPostfix('a|b*')).toEqual('ab*|');
     });
-    
+
     test('call with "a.(b|c)*.d" should return "abc|*.d."', () => {
         expect(toPostfix('a.(b|c)*.d')).toEqual('abc|*.d.');
     });

--- a/__tests__/regex.test.js
+++ b/__tests__/regex.test.js
@@ -61,4 +61,12 @@ describe('createMatcher tests', () => {
         expect(match('b')).toBeFalsy();
         expect(match('ababab')).toBeFalsy();
     });
+
+    test('from "abc|def" should recognize strings of abc or def', () => {
+        const match = createMatcher('abc|def');
+        expect(match('abc')).toBeTruthy();
+        expect(match('def')).toBeTruthy();
+        expect(match('ab')).toBeFalsy();
+        expect(match('ef')).toBeFalsy();
+    })
 });

--- a/src/parser.js
+++ b/src/parser.js
@@ -1,10 +1,10 @@
-function insertExplicitConcatOperator(exp) {    
+function insertExplicitConcatOperator(exp) {
     let output = '';
 
     for (let i = 0; i < exp.length; i++) {
         const token = exp[i];
         output += token;
-        
+
         if (token === '(' || token === '|') {
             continue;
         }
@@ -28,8 +28,8 @@ function peek(stack) {
 }
 
 const operatorPrecedence = {
-    '.': 0,
-    '|': 1,
+    '|': 0,
+    '.': 1,
     '*': 2
 };
 
@@ -43,11 +43,11 @@ function toPostfix(exp) {
                   && operatorPrecedence[peek(operatorStack)] >= operatorPrecedence[token]) {
                 output += operatorStack.pop();
             }
-            
+
             operatorStack.push(token);
         } else if (token === '(' || token === ')') {
             if(token === '(') {
-                operatorStack.push(token);                
+                operatorStack.push(token);
             } else {
                 while(peek(operatorStack) !== '(') {
                     output += operatorStack.pop();


### PR DESCRIPTION
Hi, the priority of the concat operator should be higher than the union, otherwise `match('abc|def')` would be failed.