### PR TITLE
feat: add insertExpandedOneOrMoreOperator with tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+/.vs

--- a/__tests__/parser.test.js
+++ b/__tests__/parser.test.js
@@ -1,9 +1,28 @@
 const {
+    insertExpandedOneOrMoreOperator,
     insertExplicitConcatOperator,
     toPostfix
 } = require('../src/parser');
 
-describe('insertExplicitConcatSymbol tests', () => {
+describe('insertExpandedOneOrMoreOperator tests', () => {
+    test('call with "" should return ""', () => {
+        expect(insertExpandedOneOrMoreOperator('')).toEqual('');
+    });
+    test('call with "ab*c" should return "ab*c"', () => {
+        expect(insertExpandedOneOrMoreOperator('ab*c')).toEqual('ab*c');
+    });
+    test('call with "a+" should return "(aa*)"', () => {
+        expect(insertExpandedOneOrMoreOperator('a+')).toEqual('(aa*)');
+    });
+    test('call with "ab+c" should return "a(bb*)c"', () => {
+        expect(insertExpandedOneOrMoreOperator('ab+c')).toEqual('a(bb*)c');
+    });
+    test('call with "uv+(a|b)+cw+" should return "u(vv*)((a|b)(a|b)*)c(ww*)"', () => {
+        expect(insertExpandedOneOrMoreOperator('uv+(a|b)+cw+')).toEqual('u(vv*)((a|b)(a|b)*)c(ww*)');
+    });
+});
+
+describe('insertExplicitConcatOperator tests', () => {
     test('call with "" should return ""', () => {
         expect(insertExplicitConcatOperator('')).toEqual('');
     });

--- a/__tests__/regex.test.js
+++ b/__tests__/regex.test.js
@@ -62,6 +62,39 @@ describe('createMatcher tests', () => {
         expect(match('ababab')).toBeFalsy();
     });
 
+    test('from "(a|b)+c" should recognize strings with a greater-than-zero number of a\'s and b\'s ending with c', () => {
+        const match = createMatcher('(a|b)+c');
+        expect(match('c')).toBeFalsy(); // (missing leading a's or b's)
+        expect(match('ac')).toBeTruthy();
+        expect(match('ababc')).toBeTruthy();
+        expect(match('bbbc')).toBeTruthy();
+        expect(match('aaaaaaac')).toBeTruthy();
+        expect(match('ac')).toBeTruthy();
+        expect(match('bac')).toBeTruthy();
+        expect(match('abbbbc')).toBeTruthy();
+        expect(match('cc')).toBeFalsy(); // (missing leading a's or b's)
+        expect(match('a')).toBeFalsy(); // (missing trailing c)
+        expect(match('b')).toBeFalsy(); // (idem)
+        expect(match('ababab')).toBeFalsy(); // (idem)
+    });
+
+    test('from "0x(0|1|2|3|4|5|6|7|8|9|a|b|c|d|e|f)+" should recognize the writing of an hexadecimal number', () => {
+        const match = createMatcher('0x(0|1|2|3|4|5|6|7|8|9|a|b|c|d|e|f)+');
+        expect(match('0')).toBeFalsy(); // (missing preamble)
+        expect(match('x')).toBeFalsy(); // (bad preamble #1)
+        expect(match('x0')).toBeFalsy(); // (bad preamble #2)
+        expect(match('0x')).toBeFalsy(); // (missing digits)
+        expect(match('0x0')).toBeTruthy();
+        expect(match('0x1')).toBeTruthy();
+        expect(match('0x2')).toBeTruthy();
+        expect(match('0x3')).toBeTruthy();
+        expect(match('0xf')).toBeTruthy();
+        expect(match('0x0a')).toBeTruthy();
+        expect(match('0x20')).toBeTruthy();
+        expect(match('0xfee1600d')).toBeTruthy();
+        expect(match('0xfee1Dead')).toBeFalsy(); // (capital 'D' not a recognized hexadecimal digit)
+    });
+
     test('from "abc|def" should recognize strings of abc or def', () => {
         const match = createMatcher('abc|def');
         expect(match('abc')).toBeTruthy();

--- a/src/parser.js
+++ b/src/parser.js
@@ -1,3 +1,35 @@
+function insertExpandedOneOrMoreOperator(exp) {
+    // We rewrite, say:
+    //    x*(a|b)+y+z*
+    // as:
+    //    x*((a|b)(a|b)*)(yy*)z*
+    //
+    let output = exp;
+    let index = output.indexOf('+');
+
+    // Do we have one or more term ending in '+'?
+    while (index > 0) {
+
+        // If so, rewrite them in-place (until we've exhausted all these '+'s)
+        let h = index - 1;
+        let c = 0;
+
+        // If a closing parenthesis ')' is immediately preceding the '+',
+        // we walk back, to lookup the balanced open parenthesis that matches it:
+        while ((c += (output[h] === ')' ? 1 : output[h] === '(' ? -1 : 0)) !== 0) {
+            h--;
+        }
+
+        const lhs = output.substr(0, h);
+        const mid = output.substr(h, index - h); // That'd be the "(a|b)" and "y" term in the above example
+        const rhs = output.substr(index + 1);
+
+        output = lhs + "(" + mid + mid + "*)" + rhs; // Rewrite "...<term>+..." as "...(<term><term>*)..."
+        index = output.indexOf('+');
+    }
+    return output;
+};
+
 function insertExplicitConcatOperator(exp) {
     let output = '';
 
@@ -67,6 +99,7 @@ function toPostfix(exp) {
 };
 
 module.exports = {
+	insertExpandedOneOrMoreOperator,
     insertExplicitConcatOperator,
     toPostfix
 };

--- a/src/parser.js
+++ b/src/parser.js
@@ -99,7 +99,7 @@ function toPostfix(exp) {
 };
 
 module.exports = {
-	insertExpandedOneOrMoreOperator,
+    insertExpandedOneOrMoreOperator,
     insertExplicitConcatOperator,
     toPostfix
 };

--- a/src/regex.js
+++ b/src/regex.js
@@ -1,8 +1,9 @@
-const { insertExplicitConcatOperator, toPostfix } = require('./parser');
+const { insertExplicitConcatOperator, insertExpandedOneOrMoreOperator, toPostfix } = require('./parser');
 const { toNFA, toNFAFromInfixExp, recognize } = require('./nfa');
 
 function createMatcher(exp) {
-    const expWithConcatenationOperator = insertExplicitConcatOperator(exp);
+    const expWithOneOrMoreOperator = insertExpandedOneOrMoreOperator(exp);
+	const expWithConcatenationOperator = insertExplicitConcatOperator(expWithOneOrMoreOperator);
     
     // Generates an NFA using a stack
     const postfixExp = toPostfix(expWithConcatenationOperator);

--- a/src/regex.js
+++ b/src/regex.js
@@ -3,7 +3,7 @@ const { toNFA, toNFAFromInfixExp, recognize } = require('./nfa');
 
 function createMatcher(exp) {
     const expWithOneOrMoreOperator = insertExpandedOneOrMoreOperator(exp);
-	const expWithConcatenationOperator = insertExplicitConcatOperator(expWithOneOrMoreOperator);
+    const expWithConcatenationOperator = insertExplicitConcatOperator(expWithOneOrMoreOperator);
     
     // Generates an NFA using a stack
     const postfixExp = toPostfix(expWithConcatenationOperator);


### PR DESCRIPTION
A relatively simple change to support '+' (one or more) by expanding it with the existing Kleene star implementation, whereby "`...term+...`" is rewritten as the equivalent "`...(term term*)...`" prior to the NFA construction